### PR TITLE
Better default value selection on Region fields.

### DIFF
--- a/source/source-crs.js
+++ b/source/source-crs.js
@@ -105,6 +105,10 @@
           var index = (_showEmptyCountryOption) ? countryElement.selectedIndex - 1 : countryElement.selectedIndex;
           var data = _countries[index][3];
           _setDefaultRegionValue(regionElement, data, defaultRegionSelectedValue, useShortcode);
+		  
+		  //If we weren't able to set a value, then invert useShortcode and try again in case the default value was entered differently	  
+		  if(regionElement.selectedIndex === 0)
+			_setDefaultRegionValue(regionElement, data, defaultRegionSelectedValue, !useShortcode);
         }
       } else if (_showEmptyCountryOption === false) {
         _populateRegionFields(countryElement, regionElement);


### PR DESCRIPTION
After trying to set the region dropdown from the default value. If we still haven't selected anything, we try again with the useShortcode value inverted in case the old data was stored differently.

Any downside to doing this?